### PR TITLE
`Model_Category`にリレーションを定義。

### DIFF
--- a/backend/fuel/app/classes/model/category.php
+++ b/backend/fuel/app/classes/model/category.php
@@ -1,9 +1,14 @@
 <?php
 
-// categoryテーブルのモデル
+// `categories` テーブルに対応するモデルクラス
+// このクラスは、データベースの `categories` テーブルとやり取りするためのモデル（設計図）です。
 class Model_Category extends \Orm\Model
 {
-	// テーブルのカラム
+	/**
+	 * @var array $_properties
+	 * このモデルが扱うデータベースの**カラム（列）**を定義します。
+	 * ここで定義されたプロパティが、テーブルの各カラムに対応します。
+	 */
 	protected static $_properties = array(
 		'id',
 		'name',
@@ -16,19 +21,43 @@ class Model_Category extends \Orm\Model
 		'updated_at',
 	);
 
-	// 作成日時と更新日時のオブザーバー
+	/**
+	 * @var array $_has_many
+	 * 他のモデルとの**リレーションシップ（関連付け）**を定義します。
+	 * これにより、関連するテーブルのデータを簡単に取得できるようになります。
+	 */
+	protected static $_has_many = array(
+		// Model_Category(親)に属するModel_Schedule(子)の一対多のリレーションシップ
+		// 1つのカテゴリーは複数のスケジュールを持つことができます。
+		'schedules' => array(
+			'key_from' => 'id',
+			'model_to' => 'Model_Schedule',
+			'key_to' => 'category_id',
+			'cascade_delete' => false,
+		)
+	);
+
+	/**
+	 * @var array $_observers
+	 * データベース操作の前後に自動で実行される処理（**オブザーバー**）を定義します。
+	 */
 	protected static $_observers = array(
+		// 新規レコード作成時、`created_at`カラムにタイムスタンプを自動設定するオブザーバー。
 		'Orm\Observer_CreatedAt' => array(
 			'events' => array('before_insert'),
 			'mysql_timestamp' => true,
 		),
+		// レコードが更新されるたび、`updated_at`カラムにタイムスタンプを自動設定するオブザーバー。
 		'Orm\Observer_UpdatedAt' => array(
 			'events' => array('before_save'),
 			'mysql_timestamp' => true,
 		),
 	);
 
-	// テーブル名
+	/**
+	 * @var string $_table_name
+	 * このモデルが対応するデータベースの**テーブル名**を指定します。
+	 */
 	protected static $_table_name = 'categories';
 
 }


### PR DESCRIPTION
## 📝 変更内容
`Model_Category`にリレーションを定義しました。

### 何を変更したか

<!-- 変更内容を簡潔に説明してください -->
`Model_Category`に`Model_Schedules`との一対多のリレーションを定義しました。

---

## 🧪 テスト・確認項目

### 動作確認

<!-- 実際に動作確認した内容を記載してください -->

- [x] プルリクエストにラベルを追加したか
- [x] アサインに自分を追加したか
- [ ] ローカル環境で動作確認済み
- [ ] 既存機能に影響がないことを確認

---

## 📸 スクリーンショット（UI 変更がある場合）

<!-- UI変更がある場合は、Before/Afterのスクリーンショットを貼ってください -->

| Before            | After           |
| ----------------- | --------------- |
| ![Before](before) | ![After](after) |

---

## 💡 補足事項

<!-- その他、レビュー時に注意してほしい点や参考情報があれば記載してください -->
動作確認をしたところ、`Category` → `Schedule`のリレーションシップ定義は正しく動作している
だが、`Schedule` → `Category`が正しく取得できていないため、今後何か変更があるかもしれません。
このプルリクエストにコメントする形で報告します。

---

## 🔗 関連 Issue

<!-- 関連するIssueがあれば記載してください -->

Closes #45 
