### PR TITLE
ユーザーログイン状態取得APIの実装をしました。

### DIFF
--- a/backend/fuel/app/config/routes.php
+++ b/backend/fuel/app/config/routes.php
@@ -6,6 +6,7 @@ return array(
 	'api/register' => 'api/user/register', // ユーザー登録API
 	'api/login'    => 'api/user/login', // ユーザーログインAPI
 	'api/logout'   => 'api/user/logout', // ユーザーログアウトAPI
+	'api/me'       => 'api/user/me', // ユーザーログイン状態確認API
 	
 	'hello(/:name)?' => array('welcome/hello', 'name' => 'hello'),
 );


### PR DESCRIPTION
## 📝 変更内容
ユーザーログイン状態取得APIの実装

### 何を変更したか

<!-- 変更内容を簡潔に説明してください -->
ユーザーログイン状態取得APIのルーティングの設定
ログイン状態取得メソッド
動作確認

```
curl -b cookies.txt -X GET http://localhost:80/api/me
{"status":"success","data":{"user_id":2,"username":"testuser2","logged_in":true}}
```
```
curl -b cookies.txt -X GET http://localhost:80/api/me
{"status":"success","data":{"logged_in":false}}
```

---

## 🧪 テスト・確認項目

### 動作確認

<!-- 実際に動作確認した内容を記載してください -->

- [x] プルリクエストにラベルを追加したか
- [x] アサインに自分を追加したか
- [x] ローカル環境で動作確認済み
- [x] 既存機能に影響がないことを確認

---

## 📸 スクリーンショット（UI 変更がある場合）

<!-- UI変更がある場合は、Before/Afterのスクリーンショットを貼ってください -->

| Before            | After           |
| ----------------- | --------------- |
| ![Before](before) | ![After](after) |

---

## 💡 補足事項

<!-- その他、レビュー時に注意してほしい点や参考情報があれば記載してください -->
Issue #109 この問題が発生しました。
ログアウトメソッドに

`\Auth::dont_remember_me();`
`\Cookie::delete('fuelcid', '/');`
`\Cookie::delete('remember_me', '/');`

上記を追加しました。

結果的に原因は`curl`が生成した`cookies.txt`によるキャッシュが原因だと考えています。
フロントから叩くときに改めて、cookieが削除されているのかを検証します。

---

## 🔗 関連 Issue

<!-- 関連するIssueがあれば記載してください -->

Closes #107 
