### PR TITLE
スケジュール一覧取得APIの実装をしました。

### DIFF
--- a/backend/fuel/app/classes/controller/api/schedule.php
+++ b/backend/fuel/app/classes/controller/api/schedule.php
@@ -1,0 +1,67 @@
+<?php
+
+use Fuel\Core\Controller_Rest;
+use Fuel\Core\Input;
+use Fuel\Core\Auth;
+
+class Controller_Api_Schedule extends Controller_Rest
+{
+  protected $format = 'json';
+
+  /**
+   * GET /api/schedules
+   * 指定された日付のスケジュール一覧を取得
+   */
+  public function get_index()
+  {
+    // ログインチェック
+    if (!\Auth::check()) {
+      return $this->response([
+        'status' => 'error',
+        'message' => 'Unauthorized',
+      ], 401);
+    }
+
+    // ログイン中のユーザーID
+    $user_id = \Auth::get_user_id()[1];
+
+    // クエリパラメータから date を取得
+    $date = \Input::get('date');
+
+    if (!$date) {
+      return $this->response([
+        'status' => 'error',
+        'message' => 'Missing required parameter: date',
+      ], 400);
+    }
+
+    // ORM を使ってスケジュールを取得
+    $schedules = Model_Schedule::find('all', [
+      'where' => [
+        ['user_id', $user_id],
+        ['date', $date],
+      ],
+      'order_by' => ['start_time' => 'asc'],
+    ]);
+
+    // 結果を配列化
+    $result = [];
+    foreach ($schedules as $schedule) {
+      $result[] = [
+        'id'         => $schedule->id,
+        'title'      => $schedule->title,
+        'date'       => $schedule->date,
+        'start_time' => $schedule->start_time,
+        'end_time'   => $schedule->end_time,
+        'color'      => $schedule->color,
+        'note'       => $schedule->note,
+        'category_id'=> $schedule->category_id,
+      ];
+    }
+
+    return $this->response([
+      'status' => 'success',
+      'data'   => $result,
+    ], 200);
+  }
+}


### PR DESCRIPTION
## 📝 変更内容
スケジュール一覧取得APIの実装

### 何を変更したか

<!-- 変更内容を簡潔に説明してください -->
controller/api/schedule.phpを新規作成
GETメソッドを追加
スケジュール一覧取得APIのルーティング追加
動作確認

```
curl -b cookies.txt -X GET "http://localhost:80/api/schedules?date=2025-09-26"api/schedules?
{"status":"success","data":[{"id":3,"title":"\u30df\u30fc\u30c6\u30a3\u30f3\u30b0(\u30c6\u30b9\u30c8)","date":"2025-09-26 00:00:00","start_time":"10:00:00","end_time":"11:00:00","color":"#FF0000","note":"\u30af\u30e9\u30a4\u30a2\u30f3\u30c8\u6253\u3061\u5408\u308f\u305b","category_id":null}]}
```

---

## 🧪 テスト・確認項目

### 動作確認

<!-- 実際に動作確認した内容を記載してください -->

- [ ] プルリクエストにラベルを追加したか
- [ ] アサインに自分を追加したか
- [ ] ローカル環境で動作確認済み
- [ ] 既存機能に影響がないことを確認

---

## 📸 スクリーンショット（UI 変更がある場合）

<!-- UI変更がある場合は、Before/Afterのスクリーンショットを貼ってください -->

| Before            | After           |
| ----------------- | --------------- |
| ![Before](before) | ![After](after) |

---

## 💡 補足事項

<!-- その他、レビュー時に注意してほしい点や参考情報があれば記載してください -->

---

## 🔗 関連 Issue

<!-- 関連するIssueがあれば記載してください -->

Closes #94 
