### PR TITLE
スケジュール関連のリファクタリングをした。

### DIFF
--- a/backend/fuel/app/classes/model/schedule.php
+++ b/backend/fuel/app/classes/model/schedule.php
@@ -145,4 +145,45 @@ class Model_Schedule extends \Orm\Model
 	 */
 	protected static $_table_name = 'schedules';
 
+	// ======================================================================
+	// スケジュール関連ビジネスロジック
+	// ======================================================================
+
+	/**
+	 * 指定されたユーザーの指定日のスケジュール一覧を取得
+	 * @param int $user_id ユーザーID
+	 * @param string $date 日付（YYYY-MM-DD形式）
+	 * @param string|null $start_date 開始日（期間指定時）
+	 * @param string|null $end_date 終了日（期間指定時）
+	 * @return array スケジュール一覧
+	 */
+	public static function get_user_schedules($user_id, $date = null, $start_date = null, $end_date = null)
+	{
+		$where = array(
+			array('user_id', $user_id)
+		);
+
+		// 日付条件を設定
+		if ($date) {
+			// 特定の日付
+			$where[] = array('date', $date);
+		} elseif ($start_date && $end_date) {
+			// 期間指定
+			$where[] = array('date', '>=', $start_date);
+			$where[] = array('date', '<=', $end_date);
+		}
+
+		try {
+			$schedules = static::find('all', array(
+				'where' => $where,
+				'order_by' => array('date' => 'asc', 'start_time' => 'asc'),
+			));
+
+			return static::format_schedules($schedules);
+
+		} catch (\Exception $e) {
+			\Log::error('Failed to get user schedules: ' . $e->getMessage());
+			return array();
+		}
+	}
 }


### PR DESCRIPTION
## 📝 変更内容
スケジュール関連のリファクタリング

### 何を変更したか

<!-- 変更内容を簡潔に説明してください -->
スケジュール一覧取得のメソッドをスケジュールモデルに移行
スケジュールAPIを叩く際のユーザーID取得をベースコントローラーで行うようにした。

### なぜ変更したか

<!-- 変更の理由や背景を説明してください -->
コントローラーにDBとのやり取りを書くことはMVCの設計思想に反するから

各メソッドに毎回ユーザーID取得をするのはDRY規則に反するから。

---

## 🧪 テスト・確認項目

### 動作確認

<!-- 実際に動作確認した内容を記載してください -->

- [x] プルリクエストにラベルを追加したか
- [x] アサインに自分を追加したか
- [x] ローカル環境で動作確認済み
- [x] 既存機能に影響がないことを確認

---

## 📸 スクリーンショット（UI 変更がある場合）

<!-- UI変更がある場合は、Before/Afterのスクリーンショットを貼ってください -->

| Before            | After           |
| ----------------- | --------------- |
| ![Before](before) | ![After](after) |

---

## 💡 補足事項

<!-- その他、レビュー時に注意してほしい点や参考情報があれば記載してください -->
Close #115 
スケジュールAPIを叩くときに必ずユーザーIDが必要なため、ベースコントローラーにユーザー情報を取得するコードを記述した。

ユーザーコントローラー、ユーザーモデルをベースコントローラーに合うように修正した。

---

## 🔗 関連 Issue

<!-- 関連するIssueがあれば記載してください -->

Closes #114 
