### PR TITLE
スケジュール登録APIを追加しました。

### DIFF
--- a/backend/fuel/app/config/routes.php
+++ b/backend/fuel/app/config/routes.php
@@ -10,7 +10,7 @@ return array(
 	'api/me'       => 'api/user/me', // ユーザーログイン状態確認API
 
 	// Schedule関連
-	'api/schedules' => 'api/schedule/index', // スケージュール一覧取得API
+	'api/schedules(/:id)?' => 'api/schedule', // これ一つで全てのCRUDに対応
 	
 	'hello(/:name)?' => array('welcome/hello', 'name' => 'hello'),
 );


### PR DESCRIPTION
## 📝 変更内容
スケジュール登録API追加

### 何を変更したか

<!-- 変更内容を簡潔に説明してください -->
スケジュール登録メソッドを追加
スケジュールのルーティングを一つでCRUDに対応できるものに変更
動作確認

```
curl -b cookies.txt -X POST 'http://localhost:80/api/schedules' \
-H 'Content-Type: application/x-www-form-urlencoded' \chedules' \
-d 'title=チームミーティング&date=2025-10-01&start_time=10:00:00&end_time=11:00:00&color=%233498db&category_id=1'ory_id=1'&date=2025-10-01&start_time=10:00:00&end_time=11:00:00&col

{"status":"success","data":{"id":4,"title":"\u30c1\u30fc\u30e0\u30df\u30fc\u30c6\u30a3\u30f3\u30b0","date":"2025-10-01","start_time":"10:00:00","end_time":"11:00:00","color":"#3498db","note":"","category_id":"1"}}
```

---

## 🧪 テスト・確認項目

### 動作確認

<!-- 実際に動作確認した内容を記載してください -->

- [x] プルリクエストにラベルを追加したか
- [x] アサインに自分を追加したか
- [x] ローカル環境で動作確認済み
- [x] 既存機能に影響がないことを確認

---

## 📸 スクリーンショット（UI 変更がある場合）

<!-- UI変更がある場合は、Before/Afterのスクリーンショットを貼ってください -->

| Before            | After           |
| ----------------- | --------------- |
| ![Before](before) | ![After](after) |

---

## 💡 補足事項

<!-- その他、レビュー時に注意してほしい点や参考情報があれば記載してください -->
スケジュールデータのヘルパーメソッド、
時間、日付のバリデーションを追加しました

---

## 🔗 関連 Issue

<!-- 関連するIssueがあれば記載してください -->

Closes #95
