### PR TITLE
スケジュールが存在する日付を取得するAPIの実装をした。

### DIFF
--- a/backend/fuel/app/classes/controller/api/schedule.php
+++ b/backend/fuel/app/classes/controller/api/schedule.php
@@ -176,6 +176,30 @@ class Controller_Api_Schedule extends Controller_Base_Api
     }
   }
 
+  /**
+   * GET /api/schedules/dates
+   * スケジュールが存在する日付のリストを取得 (カレンダーハイライト用)
+   */
+  public function get_dates()
+  {
+    // before()で認証済み
+    $user_id = $this->get_current_user_id();
+    $start_date = Input::get('start_date');
+    $end_date = Input::get('end_date');     
+
+    if (!$start_date || !$end_date) {
+      return $this->error('Missing start_date or end_date parameter', 400);
+    }
+    
+    try {
+      $dates = Model_Schedule::get_dates_with_schedules($user_id, $start_date, $end_date);
+      return $this->success(['highlight_dates' => $dates]);
+    } catch (\Exception $e) {
+      \Log::error('Failed to get dates: ' . $e->getMessage());
+      return $this->error('Internal Server Error', 500);
+    }
+  }
+
   // ======================================================================
   // Private Helper Methods
   // ======================================================================

--- a/backend/fuel/app/classes/model/schedule.php
+++ b/backend/fuel/app/classes/model/schedule.php
@@ -287,6 +287,33 @@ class Model_Schedule extends \Orm\Model
 	}
 
 	/**
+	 * ユーザーのスケジュールが存在する日付のリストを取得
+	 * (カレンダーの色付け機能用 - DBクラス使用)
+	 * @param int $user_id ユーザーID
+	 * @param string $start_date 期間の開始日 (YYYY-MM-DD)
+	 * @param string $end_date 期間の終了日 (YYYY-MM-DD)
+	 * @return array スケジュールが存在する日付の配列 ['YYYY-MM-DD', 'YYYY-MM-DD', ...]
+	 */
+	public static function get_dates_with_schedules($user_id, $start_date, $end_date)
+	{
+		// DBクラス (生SQL) を使用し、ユーザーIDと期間で絞り込み、日付を重複排除
+		$result = \DB::select(\DB::expr("DATE_FORMAT(`date`, '%Y-%m-%d') AS date_only"))
+			->distinct(true) 
+			->from(static::$_table_name) // 'schedules' テーブルを使用
+			->where('user_id', $user_id)
+			->where('date', '>=', $start_date)
+			->where('date', '<=', $end_date)
+			->execute(); // 結果を Database_Result オブジェクトとして取得
+
+		$dates = [];
+		foreach ($result as $row) {
+			$dates[] = $row['date_only'];
+		}
+
+		return $dates;
+	}
+
+	/**
 	 * スケジュールの時間重複チェック
 	 * @param int $user_id ユーザーID
 	 * @param string $date 日付

--- a/backend/fuel/app/config/routes.php
+++ b/backend/fuel/app/config/routes.php
@@ -10,6 +10,7 @@ return array(
 	'api/me'       => 'api/user/me', // ユーザーログイン状態確認API
 
 	// Schedule関連
+	'api/schedules/dates' => 'api/schedule/dates', // スケージュールが存在する日を取得するAPI
 	'api/schedules(/:id)?' => 'api/schedule', // これ一つで全てのCRUDに対応
 	
 	'hello(/:name)?' => array('welcome/hello', 'name' => 'hello'),


### PR DESCRIPTION
## 📝 変更内容
スケジュールが存在する日付を取得するAPIの実装

### 何を変更したか

<!-- 変更内容を簡潔に説明してください -->
スケジュールが存在する日付を取得するAPIの作成
このAPIのルーティングを追加
動作確認

```
curl -b cookies.txt 'http://localhost:80/api/schedules/dates?start_date=2025-10-01&end_date=2025-10-31'

{"status":"success","data":{"highlight_dates":["2025-10-15"]}}
```

---

## 🧪 テスト・確認項目

### 動作確認

<!-- 実際に動作確認した内容を記載してください -->

- [ ] プルリクエストにラベルを追加したか
- [ ] アサインに自分を追加したか
- [ ] ローカル環境で動作確認済み
- [ ] 既存機能に影響がないことを確認

---

## 📸 スクリーンショット（UI 変更がある場合）

<!-- UI変更がある場合は、Before/Afterのスクリーンショットを貼ってください -->

| Before            | After           |
| ----------------- | --------------- |
| ![Before](before) | ![After](after) |

---

## 💡 補足事項

<!-- その他、レビュー時に注意してほしい点や参考情報があれば記載してください -->
フロントから月の最初と最後の日付を指定して、JSONで送信すること。

---

## 🔗 関連 Issue

<!-- 関連するIssueがあれば記載してください -->

Closes #101 
